### PR TITLE
Train a test model before running pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,6 +34,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Train base model
+        run: |
+          python starter/train_model.py tests/test_rawdata.csv --artifact_path model/run002 --model_params starter/config.json
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/pytest_dev.yml
+++ b/.github/workflows/pytest_dev.yml
@@ -1,0 +1,42 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Pytest
+
+on:
+  push:
+    branches: [ "dev-pytest-workflow" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./starter
+
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Train base model
+        run: |
+          python train_model.py tests/test_rawdata.csv --artifacts model/run002 --model_params config.json
+      - name: Test with pytest
+        run: |
+          python -m pytest

--- a/.github/workflows/pytest_dev.yml
+++ b/.github/workflows/pytest_dev.yml
@@ -36,7 +36,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Train base model
         run: |
-          python starter/train_model.py tests/test_rawdata.csv --artifacts model/run002 --model_params config.json
+          python starter/train_model.py tests/test_rawdata.csv --artifact_path model/run002 --model_params config.json
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/pytest_dev.yml
+++ b/.github/workflows/pytest_dev.yml
@@ -36,7 +36,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Train base model
         run: |
-          python train_model.py tests/test_rawdata.csv --artifacts model/run002 --model_params config.json
+          python starter/train_model.py tests/test_rawdata.csv --artifacts model/run002 --model_params config.json
       - name: Test with pytest
         run: |
           python -m pytest

--- a/.github/workflows/pytest_dev.yml
+++ b/.github/workflows/pytest_dev.yml
@@ -36,7 +36,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Train base model
         run: |
-          python starter/train_model.py tests/test_rawdata.csv --artifact_path model/run002 --model_params config.json
+          python starter/train_model.py tests/test_rawdata.csv --artifact_path model/run002 --model_params starter/config.json
       - name: Test with pytest
         run: |
           python -m pytest


### PR DESCRIPTION
Adding a step to train a base model on only two record, in order for the FastAPI app to have a model to serve, which can be tested by pytest